### PR TITLE
Loadtest dev ops 2528

### DIFF
--- a/constant.py
+++ b/constant.py
@@ -4,11 +4,12 @@ from bbbTaskSet import *
 from scTaskSet import *
 from docTaskSet import *
 from reqWithoutUserTaskSet import *
+from rocketChatTaskSet import *
 from locust import between
 
 class constant():
     wait_time = between(5, 15) # Provides a random number which will be used as waiting time for the users
-    tasks = {bbbTaskSet:1, scTaskSet:3, docTaskSet:1, reqWithoutUserTaskSet:1} # Conatins all task-sets which will be applied on the users
+    tasks = {bbbTaskSet:1, scTaskSet:3, docTaskSet:1, reqWithoutUserTaskSet:1, rocketChatTaskSet:1} # Conatins all task-sets which will be applied on the users
     MATRIX_MESSENGER = os.environ.get("MMHOST")
     timeToWaitShort = int(os.environ.get("TIMESHORT"))
     timeToWaitLong = int(os.environ.get("TIMELONG"))

--- a/docTaskSet.py
+++ b/docTaskSet.py
@@ -25,14 +25,12 @@ class docTaskSet(TaskSet):
         '''
         First task on docTaskSet, which starts the login of the user.
         '''
-
         login(self)
 
     def on_stop(self):
         '''
         Last task on docTaskSet, which will be triggerd after stopping the loadtest. Automatically starts a clean-up and loggs out the user.
         '''
-
         logout(self)
 
     @tag('doc')

--- a/functions.py
+++ b/functions.py
@@ -310,6 +310,10 @@ def deleteTeam(self, teamId):
             response.failure(requestFailureMessage(self, response))
 
 def loginLoadtestUserOnTeamToEdit(self, webbrowser):
+    '''
+    Logs-in a user on the 'edit-page' of a team on SchulCloud.
+    '''
+    
     # Login user
     ui_element = "input[id='name']"
     element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
@@ -322,12 +326,13 @@ def loginLoadtestUserOnTeamToEdit(self, webbrowser):
     ui_element = "input[id='submit-login']"
     element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
     element.click()
+    
     time.sleep(1)
 
 def enableTeamMessenger(webbrowser):
     '''
-    Enables the team-messenger. This will create a new chat on RocketChat. When the team will be deleted later, the connected rocket chat will be deleted as well. 
-    Only works with an already startet webbrowser, where the user is already logged in.
+    Enables the team-messenger. This will create a new chat on RocketChat. When the team will be deleted later, 
+    the connected rocket chat will be deleted as well. Only works with an already startet webbrowser, where the user is already logged in.
     '''
     
     # Klick on rocket chat checkbox

--- a/functions.py
+++ b/functions.py
@@ -1,9 +1,15 @@
 import json
-
-from requests.api import head
+from random import betavariate
 import locustfile
 import requests
+import time
+import requestsBuilder
 
+from selenium.webdriver.support import expected_conditions as EC # available since 2.26.0
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait # available since 2.4.0
+from selenium import webdriver
+from requests.api import head
 from requestsBuilder import *
 
 def createDoc(self, docdata):
@@ -303,88 +309,80 @@ def deleteTeam(self, teamId):
         if response.status_code != constant.constant.returncodeNormal:
             response.failure(requestFailureMessage(self, response))
 
-def enableTeamMessenger(self):#, teamId):
+def loginLoadtestUserOnTeamToEdit(self, webbrowser):
+    # Login user
+    ui_element = "input[id='name']"
+    element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
+    element.send_keys(self.user.login_credentials["email"])
+
+    ui_element = "input[id='password']"
+    element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
+    element.send_keys(self.user.login_credentials["password"])
+
+    ui_element = "input[id='submit-login']"
+    element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
+    element.click()
+    time.sleep(1)
+
+def enableTeamMessenger(webbrowser):
     '''
-    Opens the team settings and enables the team-messenger. This will create a new chat on RocketChat.
+    Enables the team-messenger. This will create a new chat on RocketChat. When the team will be deleted later, the connected rocket chat will be deleted as well. 
+    Only works with an already startet webbrowser, where the user is already logged in.
+    '''
+    
+    # Klick on rocket chat checkbox
+    ui_element = "input[id='activateRC']"
+    element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
+    element.click()
+    time.sleep(1)
+
+    # Apply changes
+    ui_element = "button[data-testid='create_team_btn']"
+    element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
+    element.click()
+    time.sleep(1)
+
+
+def findTeamChatId(self, teamId):
+    '''
+    Returns the team-chat-id of the provided team.
     '''
 
-    url = f"{self.user.host}/team/61093a27bb528e001c7aa4b3/edit"
+    url = f"{self.user.host}/teams/{teamId}"
 
-    data = {
-        "schoolId": self.school_id,
-        "_method": "patch",
-        "name": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        "description": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-        "messenger": "true",
-        "rocketChat": "true",
-        "videoconference": "true",
-        "color": "#d32f2f",
-        "_csrf": self.csrf_token
-    }
-
-    header = {
-        "Host": "staging.niedersachsen.hpi-schul-cloud.org",
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:90.0) Gecko/20100101 Firefox/90.0",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "de,en-US;q=0.7,en;q=0.3",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Referer": "https://staging.niedersachsen.hpi-schul-cloud.org/teams/61093a27bb528e001c7aa4b3/edit",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Content-Length": "263",
-        "Origin": "https://staging.niedersachsen.hpi-schul-cloud.org",
-        "DNT": "1",
-        "Connection": "keep-alive",
-        "Upgrade-Insecure-Requests": "1",
-        "Sec-Fetch-Dest": "document",
-        "Sec-Fetch-Mode": "navigate",
-        "Sec-Fetch-Site": "same-origin",
-        "Sec-Fetch-User": "?1",
-        "Sec-GPC": "1",
-        "TE": "trailers",
-    }
-
-    with requests.post(url, headers=header, data=data) as response:
-        print(f"post request 61093a27bb528e001c7aa4b3 : {response.status_code}")
-    
-    # with self.client.request(
-    #     "POST",
-    #     url, 
-    #     headers=header,
-    #     data=data,
-    #     catch_response=True,
-    #     allow_redirects=True
-    # ) as response:
-    #     print(f"post request 61093a27bb528e001c7aa4b3 : {response.status_code}")
+    # Get team-chat-id
+    with self.client.request(
+        "GET",
+        url,
+        headers = requestsBuilder.requestHeaderBuilder(self, self.user.host),
+        catch_response = True,
+        allow_redirects = True
+    ) as response:
+        if response.status_code == constant.constant.returncodeNormal:
+            soup = BeautifulSoup(response.text, 'html.parser')
+            teamChatId = soup.find('iframe')['src']
+            host = self.user.host.replace("https://", "")
+            return teamChatId.replace('?layout=embedded', '').replace(f"https://chat.{host}/group/", '')
+        else:
+            response.failure(requestFailureMessage(self, response))
 
 
+def postTeamChatMessage(self, webbrowser):
+    '''
+    Posts a message on rocket chat.
+    '''
 
-    # url = f"{self.user.host}/teams/{teamId}/edit"
-    
-    # data = {
-    #     "schoolId"      : self.school_id,
-    #     "_method"       : "patch",
-    #     "name"          : "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-    #     "description"   : "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-    #     "messenger"     : "true",
-    #     "rocketChat"    : "true",
-    #     "color"         : "#d32f2f",
-    #     "_csrf"         : self.csrf_token
-    # }
+    # Type in the test message
+    ui_element = "textarea[class='rc-message-box__textarea js-input-message']"
+    element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
+    element.send_keys("This is an automated loadtest chat message.")
 
-    # headers = {
-    #     "accept-language"           : "en-US,en;q=0.9",
-    #     "Referer"                   : f"{self.user.host}/teams/{teamId}/edit",
-    #     "Content-Type"              : "application/x-www-form-urlencoded",
-    #     "Origin"                    : self.user.host,
-    #     # "DNT"                       : 1,
-    #     "Connection"                : "keep-alive",
-    #     # "Upgrade-Insecure-Requests" : 1
-    # }
+    # Klick 'send' button
+    ui_element = "svg[class='rc-icon rc-input__icon-svg rc-input__icon-svg--send']"  
+    element = WebDriverWait(webbrowser, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, ui_element)))
+    element.click()
 
-    # with requests.post(url, data=data, headers=headers) as response:
-    #     print(f"[enableTeamMessenger] post request {teamId} : {response.status_code}")
-
-
+    time.sleep(1)
 
 
 def matrixMessenger(self):

--- a/functions.py
+++ b/functions.py
@@ -1,5 +1,8 @@
 import json
+
+from requests.api import head
 import locustfile
+import requests
 
 from requestsBuilder import *
 
@@ -299,6 +302,90 @@ def deleteTeam(self, teamId):
     ) as response:
         if response.status_code != constant.constant.returncodeNormal:
             response.failure(requestFailureMessage(self, response))
+
+def enableTeamMessenger(self):#, teamId):
+    '''
+    Opens the team settings and enables the team-messenger. This will create a new chat on RocketChat.
+    '''
+
+    url = f"{self.user.host}/team/61093a27bb528e001c7aa4b3/edit"
+
+    data = {
+        "schoolId": self.school_id,
+        "_method": "patch",
+        "name": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "description": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        "messenger": "true",
+        "rocketChat": "true",
+        "videoconference": "true",
+        "color": "#d32f2f",
+        "_csrf": self.csrf_token
+    }
+
+    header = {
+        "Host": "staging.niedersachsen.hpi-schul-cloud.org",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:90.0) Gecko/20100101 Firefox/90.0",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "de,en-US;q=0.7,en;q=0.3",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Referer": "https://staging.niedersachsen.hpi-schul-cloud.org/teams/61093a27bb528e001c7aa4b3/edit",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": "263",
+        "Origin": "https://staging.niedersachsen.hpi-schul-cloud.org",
+        "DNT": "1",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-User": "?1",
+        "Sec-GPC": "1",
+        "TE": "trailers",
+    }
+
+    with requests.post(url, headers=header, data=data) as response:
+        print(f"post request 61093a27bb528e001c7aa4b3 : {response.status_code}")
+    
+    # with self.client.request(
+    #     "POST",
+    #     url, 
+    #     headers=header,
+    #     data=data,
+    #     catch_response=True,
+    #     allow_redirects=True
+    # ) as response:
+    #     print(f"post request 61093a27bb528e001c7aa4b3 : {response.status_code}")
+
+
+
+    # url = f"{self.user.host}/teams/{teamId}/edit"
+    
+    # data = {
+    #     "schoolId"      : self.school_id,
+    #     "_method"       : "patch",
+    #     "name"          : "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    #     "description"   : "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    #     "messenger"     : "true",
+    #     "rocketChat"    : "true",
+    #     "color"         : "#d32f2f",
+    #     "_csrf"         : self.csrf_token
+    # }
+
+    # headers = {
+    #     "accept-language"           : "en-US,en;q=0.9",
+    #     "Referer"                   : f"{self.user.host}/teams/{teamId}/edit",
+    #     "Content-Type"              : "application/x-www-form-urlencoded",
+    #     "Origin"                    : self.user.host,
+    #     # "DNT"                       : 1,
+    #     "Connection"                : "keep-alive",
+    #     # "Upgrade-Insecure-Requests" : 1
+    # }
+
+    # with requests.post(url, data=data, headers=headers) as response:
+    #     print(f"[enableTeamMessenger] post request {teamId} : {response.status_code}")
+
+
+
 
 def matrixMessenger(self):
     '''

--- a/locustfile.py
+++ b/locustfile.py
@@ -7,6 +7,7 @@ import constant
 
 from urllib.parse import urlparse
 from locust import HttpUser, between
+
 class PupilUser(HttpUser):
     ''' 
     Representing a pupil user on the SchulCloud.

--- a/loginout.py
+++ b/loginout.py
@@ -82,4 +82,5 @@ def cleanUpLoadtest(self):
                 findId = soup.find_all({"data-id":teamId})
             if not findId is None:
                 deleteTeam(self, teamId)
+                print(f"[loginout] Deleted {teamId}.")
         self.createdTeams = None

--- a/rocketChatTaskSet.py
+++ b/rocketChatTaskSet.py
@@ -6,11 +6,13 @@ import time
 from locust.user.task import TaskSet, tag, task
 from selenium.webdriver.support import expected_conditions as EC # available since 2.26.0
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait # available since 2.4.0
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 class rocketChatTaskSet(TaskSet):
+    '''
+    This class defines the TaskSet for RocketChat.
+    '''
 
     # Lists which contain all the doc/courses/teams ID's beeing created from the loadtest. 
     # All three lists are necessary for a clean log-out process in 'loginout'.
@@ -30,7 +32,12 @@ class rocketChatTaskSet(TaskSet):
         '''
         This task creates a new team and enables the team-messenger (settings). Afterwards, it opens the team-messenger and 
         posts some chat messanges. At the end, the created team will be deleted. 
-        Note: only teacher or admins can create a new team.
+        
+        Note: Only teacher or admins can create a new team. Because there are many bugs on enabling RocketChat for a team on the SchulCloud,
+        this method contains several workarounds.
+
+        Param:
+        - self (TaskSet) : TaskSet for RocketChat
         '''
         
         if isinstance(self._user, locustfile.PupilUser) is False:

--- a/rocketChatTaskSet.py
+++ b/rocketChatTaskSet.py
@@ -1,0 +1,39 @@
+import functions
+import loginout
+import locustfile
+
+from locust.user.task import TaskSet, tag, task
+
+class rocketChatTaskSet(TaskSet):
+
+    # Lists which contain all the doc/courses/teams ID's beeing created from the loadtest. 
+    # All three lists are necessary for a clean log-out process in 'loginout'.
+    createdDocuments = []
+    createdCourses = []
+    createdTeams = []
+
+    def on_start(self):
+        loginout.login(self)
+
+    def on_stop(self):
+        loginout.logout(self)
+
+    @tag('rocketChat')
+    @task
+    def createTeamWithRocketChat(self):
+        '''
+        This task creates a new team and enables the team-messenger (settings). Afterwards, it opens the team-messenger and 
+        posts some chat messanges. At the end, the created team will be deleted. 
+        Note: only teacher or admins can create a new team.
+        '''
+        # Create team
+        # Enable team messenger
+        # Post messages
+        # Delete team -> functions.deleteTeam(self, teamId)
+
+        if isinstance(self._user, locustfile.PupilUser) is False:
+            teamId = functions.newTeam(self)
+            functions.enableTeamMessenger(self)#, teamId)
+        
+
+        


### PR DESCRIPTION
# Description

[[OPS-2528]](https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2528) Added TaskSet for testing RocketChat
- Creates a new team
- Starts a browser and navigates to the team
- Edits and enables 'messenger'
- Gets team-chat-id and opens the chat on RocketChat
- Types and posts the message
- Closes the browser
- The team (and Chat) will be deleted within the cleanUp task in the logout method
   
NOTE: RocketChat messenger iframe has many bugs on the SchulCloud website (e.g. enabling messenger), so this TaskSet has many work-arounds included.